### PR TITLE
Small bug where we could only use enter to save the description

### DIFF
--- a/src/main/java/com/ateam/onpoint/gui/components/TaskList.java
+++ b/src/main/java/com/ateam/onpoint/gui/components/TaskList.java
@@ -75,20 +75,13 @@ public class TaskList extends ListView<TaskList.TaskRecord> {
                     this.getItem().description = descriptionField.getText();
                 }
             });
-            /*descriptionField.setOnMouseClicked(e -> {
-                if (descriptionField.isEditable()) {
-                    this.getListView().getSelectionModel().select(this.getItem());
-                }
-            });
-           */
 
-            descriptionField.focusedProperty().addListener((obs, oldVal, newVal) -> {
-                if (!newVal) { // If TextField loses focus save description
+            descriptionField.setOnMouseExited(e -> {
                     descriptionField.setEditable(false);
                     descriptionField.setMouseTransparent(true);
                     TaskManager.getInstance().changeTaskDescription(this.getItem().index, descriptionField.getText());
                     this.getItem().description = descriptionField.getText();
-                }
+
             });
             return descriptionField;
         }

--- a/src/main/java/com/ateam/onpoint/gui/components/TaskList.java
+++ b/src/main/java/com/ateam/onpoint/gui/components/TaskList.java
@@ -75,9 +75,19 @@ public class TaskList extends ListView<TaskList.TaskRecord> {
                     this.getItem().description = descriptionField.getText();
                 }
             });
-            descriptionField.setOnMouseClicked(e -> {
+            /*descriptionField.setOnMouseClicked(e -> {
                 if (descriptionField.isEditable()) {
                     this.getListView().getSelectionModel().select(this.getItem());
+                }
+            });
+           */
+
+            descriptionField.focusedProperty().addListener((obs, oldVal, newVal) -> {
+                if (!newVal) { // If TextField loses focus save description
+                    descriptionField.setEditable(false);
+                    descriptionField.setMouseTransparent(true);
+                    TaskManager.getInstance().changeTaskDescription(this.getItem().index, descriptionField.getText());
+                    this.getItem().description = descriptionField.getText();
                 }
             });
             return descriptionField;


### PR DESCRIPTION
Added a listener which when focus is changed it is triggered. If it loses focus then the TextField saves the description.

Allows user to use mouse click to save instead of just enter.
